### PR TITLE
frida17-workaround

### DIFF
--- a/Frida 0x8/Solution/Solution.md
+++ b/Frida 0x8/Solution/Solution.md
@@ -422,6 +422,29 @@ Interceptor.attach(strcmp_adr, {
 
 ```
 
+### Frida >= 17 workaround
+
+
+```javascript
+Process.attachModuleObserver({
+    onAdded: function (module) {
+        if (module.name === "libfrida0x8.so") {
+            var strcmp_adr = module.getExportByName("strcmp");
+            Interceptor.attach(strcmp_adr, {
+                onEnter: function (args) {
+                    if (args[0].isNull() || args[1].isNull()) return;
+                    var str1 = args[0].readCString();
+                    var str2 = args[1].readCString();
+                    if (str1 === "Hello") {
+                        console.log(" Our Input: " + str1 + "  Secret: " + str2);
+                    }
+                }
+            });
+        }
+    },
+    onRemoved: function (module) {}
+});
+```
 Let's run it.
 
 ![](images/27.png)

--- a/Frida 0x9/Solution/Solution.md
+++ b/Frida 0x9/Solution/Solution.md
@@ -84,6 +84,28 @@ Interceptor.attach(check_flag, {
     }
 });
 ```
+### Frida >= 17 workaround
+
+```javascript
+Process.attachModuleObserver({
+    onAdded: function(module) {
+        if (module.name === "liba0x9.so") {
+            var checkFlagAddr = module.getExportByName("Java_com_ad2001_a0x9_MainActivity_check_1flag");
+            if (checkFlagAddr) {
+                Interceptor.attach(checkFlagAddr, {
+                    onEnter: function(args) {
+                        console.log(" check_flag is being called!");
+                    },
+                    onLeave: function(returnValue) {
+                        returnValue.replace(1337); 
+                    }
+                });
+            }
+        }
+    },
+    onRemoved: function(module) {}
+});
+```
 
 Let's run this script and see what happens.
 

--- a/Frida 0xA/Solution/Solution.md
+++ b/Frida 0xA/Solution/Solution.md
@@ -166,7 +166,29 @@ var get_flag_ptr = new NativePointer(adr);
 const get_flag = new NativeFunction(get_flag_ptr, 'void', ['int', 'int']);
 get_flag(1,2);
 ```
+### Frida >= 17 workaround
 
+```javascript
+Process.attachModuleObserver({
+    onAdded: function(module) {
+        if (module.name === "libfrida0xa.so") {
+            console.log("libfrida0xa.so found at: " + module.base);
+            var offset = 0x1dd60; 
+            var getFlagAddr = module.base.add(offset);
+
+            if (getFlagAddr) {
+                console.log("Success! Function address: " + getFlagAddr);
+                var get_flag = new NativeFunction(getFlagAddr, 'void', ['int', 'int']);
+                get_flag(1, 2);                
+                console.log("Done. Check Logcat for the 'Decrypted Flag' message.");
+            } else {
+                console.log("Failed to locate the function.");
+            }
+        }
+    },
+    onRemoved: function(module) {}
+});
+```
 Let's run frida and try this script.
 
 ![](images/14.png)

--- a/Frida 0xB/Solution/Solution.md
+++ b/Frida 0xB/Solution/Solution.md
@@ -333,6 +333,27 @@ try {
 
 In ARM64, you don't have to worry about the alignment of the instructions as all the instructions are 4 bytes aligned.
 
+### Frida >= 17 workaround
+
+```javascript
+Process.attachModuleObserver({
+    onAdded: function(module) {
+        if (module.name === "libfrida0xb.so") {
+            console.log(`Found libfrida0xb.so at: ${module.base}`);
+            const targetAddress = module.base.add(0x15248);
+
+            Memory.patchCode(targetAddress, 4, (code) => {
+                const cw = new Arm64Writer(code, { pc: targetAddress });
+                cw.putNop();
+                cw.flush();
+                console.log(`Instruction at ${targetAddress} successfully patched with NOP!`);
+            });
+        }
+    },
+    onRemoved: function(module) {}
+});
+```
+
 Okay, now let's run this script and see what happens.
 
 ![](images/26.png)


### PR DESCRIPTION
Since there is some important changes in frida api and execution ways, provided solution were not working for frida 17 and above in android 16  devices. I have added the frida17-workaround (solution) that runs even in latest android device(16 currently) and latest frida version(17.X.X)